### PR TITLE
Fix MODE_CONTROL3 register address

### DIFF
--- a/library/bh1745/__init__.py
+++ b/library/bh1745/__init__.py
@@ -52,7 +52,7 @@ class BH1745:
                     1: 0b00, 2: 0b01, 16: 0b10}))
             )),
 
-            Register('MODE_CONTROL3', 0x43, fields=(
+            Register('MODE_CONTROL3', 0x44, fields=(
                 BitField('on', 0b11111111, adapter=LookupAdapter({True: 2, False: 0})),
             )),
 


### PR DESCRIPTION
While developing a device driver for this sensor I used your library as reference to check if my library is working correctly and somehow got different measurement results for the red channel. After 2 hours of staring at my code and wondering where my bug is I finally discovered that it seems like the bug is actually in this library 😄

MODE_CONTROL3 Register should actually be 0x44 instead of 0x43, this will influence, as far as I see it, only the reading for the red channel and as far as my testing goes (which wasn't very extensive) it improves the measurements to a small extent.

Also a little note regarding the product page on pimoroni.de: The datasheet link is broken since it seems like the manufacturer has taken the ressource offline. Your UK page already updated the link.